### PR TITLE
Sprint3 alustavat featuret

### DIFF
--- a/src/main/java/vinkr/TextUI.java
+++ b/src/main/java/vinkr/TextUI.java
@@ -285,6 +285,7 @@ public class TextUI {
             if (validoija.validoiLinkki(vinkki) == true) {
                 try {
                     app.getVinkit().get(Integer.parseInt(vinkki) - 1).avaaLinkki();
+                    output.println("Avataan linkkiä");
                 } catch (IOException | URISyntaxException e) {
                     output.println("Virhe: Linkin avaaminen ei onnistu");
                 } catch (Exception e) {
@@ -293,6 +294,7 @@ public class TextUI {
                 break;
             } else {
                 output.println("Virhe: Anna kelvollinen vinkin numero");
+                break;
             }
         }
     }

--- a/src/main/java/vinkr/TextUI.java
+++ b/src/main/java/vinkr/TextUI.java
@@ -285,7 +285,6 @@ public class TextUI {
             if (validoija.validoiLinkki(vinkki) == true) {
                 try {
                     app.getVinkit().get(Integer.parseInt(vinkki) - 1).avaaLinkki();
-                    output.println("Avataan linkkiä");
                 } catch (IOException | URISyntaxException e) {
                     output.println("Virhe: Linkin avaaminen ei onnistu");
                 } catch (Exception e) {

--- a/src/test/java/vinkr/Stepdefs.java
+++ b/src/test/java/vinkr/Stepdefs.java
@@ -72,6 +72,18 @@ public class Stepdefs {
         
         nykyOtsikko = otsikko;
     }
+    
+    @Given("uusi youtubevinkki, urlilla {string}, otsikolla {string}, kanavalla {string} ja julkaisupaivalla {string} annetaan")
+    public void lisataanJarjestelmaanTiettyYoutubevinkki(String url, String otsikko, String kanava, String julkaisupaiva) {
+        input += "lisaa" + "\n";
+        input += "youtube" + "\n";
+        input += url + "\n";
+        input += otsikko + "\n";
+        input += kanava + "\n";
+        input += julkaisupaiva + "\n";
+        
+        nykyOtsikko = otsikko;
+    }
         //WHENIT
     
     @When("listataan kaikki lukuvinkit")
@@ -285,6 +297,18 @@ public class Stepdefs {
         assertTrue(outputTaulukkona[otsikonIndeksi - 1].contains(vari));
     }
     
+    @Then("ohjelma vastaa tulosteella, jossa youtubevideon vari {string}")
+    public void tulosteessaVideossaHaluttuVari(String vari) throws UnsupportedEncodingException {
+        vari = muunnaAnsiKoodiksi(vari);
+        
+        String[] outputTaulukkona = muunnaOutputTaulukoksi();
+        int otsikonIndeksi = etsiTaulukostaKohta(outputTaulukkona, nykyOtsikko);
+        
+        assertTrue(vari != null);
+        //kts. huomiot kirjavinkin värin etsivässä testissä - nyt otsikko kuitenkin heti tyypin jälkeen
+        assertTrue(outputTaulukkona[otsikonIndeksi - 1].contains(vari));
+    }
+    
     // ei vielä käytössä
     @Then("ohjelma reagoi tulosteella {string}")
     public void ohjelmanViimeisinTulostettuRivi(String odotettuTuloste) throws UnsupportedEncodingException {
@@ -341,6 +365,10 @@ public class Stepdefs {
         
         if (vari.equals("sinivihrea")) {
             return Varit.SINIVIHREA;
+        }
+        
+        if (vari.equals("violetti")) {
+            return Varit.VIOLETTI;
         }
         
         return null;

--- a/src/test/java/vinkr/Stepdefs.java
+++ b/src/test/java/vinkr/Stepdefs.java
@@ -59,7 +59,23 @@ public class Stepdefs {
         
         nykyOtsikko = otsikko;
     }
-    
+    /* -- ei vielä toteutettu
+    @Given("uusi kirjavinkki, otsikolla {string}, kirjoittajalla {string}, jonka ISBN on {string}, julkaisupaikalla {string}, kustantajalla {string}, julkaisuvuodella {string} ja lukuprosentilla {string} lisataan")
+    public void lisataanJarjestelmaanTiettyKirjavinkkiLukuprosentilla(String otsikko, String kirjoittaja, String isbn, String julkaisupaikka, String kustantaja, String julkaisuvuosi, String lukuprosentti) {
+        input += "lisaa" + "\n";
+        input += "kirja" + "\n";
+        input += isbn + "\n";
+        input += otsikko + "\n";
+        input += kirjoittaja + "\n";
+        input += "\n";
+        input += julkaisupaikka + "\n";
+        input += kustantaja + "\n";
+        input += julkaisuvuosi + "\n";
+        input += lukuprosentti + "\n";
+        
+        nykyOtsikko = otsikko;
+    }
+    */
     @Given("uusi artikkelivinkki, urlilla {string}, otsikolla {string}, kirjoittajalla {string}, julkaisulla {string} ja julkaisupaivalla {string} annetaan")
     public void lisataanJarjestelmaanTiettyArtikkelivinkki(String url, String otsikko, String kirjoittaja, String julkaisu, String julkaisupaiva) {
         input += "lisaa" + "\n";
@@ -251,7 +267,16 @@ public class Stepdefs {
         
         luoUIjaStreamit();
     }
-    
+    /* -- ei vielä toteutettu
+    @When("kayttaja valitsee vinkin numero {string} ja maarittaa sen lukuprosentiksi {string}")
+    public void kayttajaMuuttaaLukuprosentin(String numero, String lukuprosentti) {
+        input += numero + "\n";
+        input += lukuprosentti + "\n";
+        input += "lopeta" + "\n";
+        
+        luoUIjaStreamit();
+    }
+    */
         //THENIT
     
     @Then("ohjelmaan tulostuu {string}")
@@ -315,7 +340,24 @@ public class Stepdefs {
         String[] outputTaulukkona = muunnaOutputTaulukoksi();
         //lisää koodia viimeisen rivin poimimiseen
     }
+    /* -- ei vielä toteutettu
+    @Then("juuri lisatyn kirjavinkin lukuprosentti on listauksessa {string}")
+    public void listauksessaOikeaLukuprosentti(String lukuprosentti) throws UnsupportedEncodingException {
+        String[] outputTaulukkona = muunnaOutputTaulukoksi();
+        int otsikonIndeksi = etsiTaulukostaKohta(outputTaulukkona, nykyOtsikko);
+         //kts. huomiot kirjavinkin värin etsivässä testissä
+        assertTrue(outputTaulukkona[otsikonIndeksi + 4].contains(lukuprosentti));
+    }
+    @Then("juuri lisatyn kirjavinkin lukuprosentin vari on listauksessa {string}")
+    public void listauksessaOikeaLukuprosentinVari(String vari) throws UnsupportedEncodingException {
+        vari = muunnaAnsiKoodiksi(vari);
+        String[] outputTaulukkona = muunnaOutputTaulukoksi();
+        int otsikonIndeksi = etsiTaulukostaKohta(outputTaulukkona, nykyOtsikko);
+         //kts. huomiot kirjavinkin värin etsivässä testissä
+        assertTrue(outputTaulukkona[otsikonIndeksi + 4].contains(vari));
+    }
     
+    */
     
     // APUMETODEJA
     private void luoUIjaStreamit() {

--- a/src/test/resources/vinkr/autotaydennys.feature
+++ b/src/test/resources/vinkr/autotaydennys.feature
@@ -1,0 +1,2 @@
+Feature: Käyttäjä voi syöttää komennon ensimmäiset kirjaimet jonka jälkeen ohjelma täydentää komennon loppuosan automaattisesti
+

--- a/src/test/resources/vinkr/hae_kirjavinkki_verkosta.feature
+++ b/src/test/resources/vinkr/hae_kirjavinkki_verkosta.feature
@@ -1,0 +1,1 @@
+Feature: Käyttäjä voi hakea kirjaVinkin tiedot automaattisesti verkosta syöttämällä teoksen ISBN-numeron

--- a/src/test/resources/vinkr/lisaa_artikkeli_ja_yb.feature
+++ b/src/test/resources/vinkr/lisaa_artikkeli_ja_yb.feature
@@ -32,5 +32,5 @@ Feature: Käyttäjä voi lisätä artikkeli- tai Youtube-videomuotoisen vinkkity
 
     Scenario: Linkin avaaminen ei onnistu, jos annettu numero ei vastaa mitään vinkkiä
         Given komento "avaa" annetaan ohjelmalle
-        When  kayttaja valitsee vinkin numero "0"
+        When  kayttaja valitsee vinkin numero "777"
 	Then  ohjelmaan tulostuu "Virhe: Anna kelvollinen vinkin numero"

--- a/src/test/resources/vinkr/lisaa_tagi.feature
+++ b/src/test/resources/vinkr/lisaa_tagi.feature
@@ -1,0 +1,1 @@
+Feature: Käyttäjä voi lisätä tageja lukuvinkkeihin niin, että ne näkyvät vinkin tiedoissa

--- a/src/test/resources/vinkr/lukuprosentit.feature
+++ b/src/test/resources/vinkr/lukuprosentit.feature
@@ -1,0 +1,1 @@
+Feature: Käyttäjä voi merkitä lukuvinkkiin kuinka monta prosenttia siitä on lukenut, nähdä vinkkien lukuprosentit listauksessa ja päivittää niitä

--- a/src/test/resources/vinkr/lukuprosentit.feature
+++ b/src/test/resources/vinkr/lukuprosentit.feature
@@ -1,1 +1,16 @@
 Feature: Käyttäjä voi merkitä lukuvinkkiin kuinka monta prosenttia siitä on lukenut, nähdä vinkkien lukuprosentit listauksessa ja päivittää niitä
+
+Scenario: Käyttäjän määrittämä lukuprosentti lukuvinkille näkyy listauksessa
+        Given uusi kirjavinkki, otsikolla "The Art of Computer Programming", kirjoittajalla "Knuth, Donald", jonka ISBN on "0-201-03801-3", julkaisupaikalla "USA", kustantajalla "kustantaja" ja julkaisuvuodella "2008" lisataan
+        When  komento "listaa" annetaan ohjelmalle
+        Then  juuri lisatyn kirjavinkin lukuprosentti on listauksessa "0"
+
+Scenario: Käyttäjän voi muuttaa tietyn lukuvinkin lukuprosenttia
+        Given komento "lue" annetaan ohjelmalle
+        When  kayttaja valitsee vinkin numero "1" ja maarittaa sen lukuprosentiksi "25"
+        Then  ohjelmaan tulostuu "Lukuprosentti päivitetty"
+
+Scenario: Tulostettujen lukuvinkkien lukuprosentit näkyvät eri väreissä
+        Given uusi kirjavinkki, otsikolla "The Art of Computer Programming", kirjoittajalla "Knuth, Donald", jonka ISBN on "0-201-03801-3", julkaisupaikalla "USA", kustantajalla "kustantaja", julkaisuvuodella "2008" ja lukuprosentilla "10" lisataan     
+	When  komento "listaa" annetaan ohjelmalle
+        Then  juuri lisatyn kirjavinkin lukuprosentin vari on listauksessa "keltainen"

--- a/src/test/resources/vinkr/tallenna_vinkit.feature
+++ b/src/test/resources/vinkr/tallenna_vinkit.feature
@@ -5,5 +5,5 @@ Feature: Syötetyt lukuvinkit säilyvät käyttökerrasta toiseen
 	When  komento "tallenna" annetaan ohjelmalle
 	And   ohjelma kaynnistetaan uudestaan
         And   listataan kaikki lukuvinkit
-        Then  ohjelma vastaa tulosteella, jossa kohdat "Tyyppi: Kirja", "Tekijä: Knuth, Donald", "Nimeke: The Art of Computer Programming" ja "ISBN: 0-201-03801-3"
+        Then  ohjelma vastaa tulosteella, jossa kohdat "Tyyppi: Kirja", "Tekijä: Martin, Robert", "Nimeke: Clean Code: A Handbook of Agile Software Craftsmanship" ja "ISBN: 978-0132350884"
 

--- a/src/test/resources/vinkr/varit_vinkkityypeissa.feature
+++ b/src/test/resources/vinkr/varit_vinkkityypeissa.feature
@@ -1,0 +1,1 @@
+Feature: Käyttäjä voi tunnistaa eri vinkkityypit värien perusteella ja nähdä niiden lukuasteen (aloittamatta/kesken/valmis) lukuprosentin väristä

--- a/src/test/resources/vinkr/varit_vinkkityypeissa.feature
+++ b/src/test/resources/vinkr/varit_vinkkityypeissa.feature
@@ -1,1 +1,12 @@
-Feature: Käyttäjä voi tunnistaa eri vinkkityypit värien perusteella ja nähdä niiden lukuasteen (aloittamatta/kesken/valmis) lukuprosentin väristä
+Feature: Käyttäjä voi tunnistaa eri vinkkityypit värien perusteella ja nähdä niiden lukuasteen lukuprosentin väristä
+
+Scenario: Listattu kirjavinkki tulostuu halutulla värillä
+        Given uusi kirjavinkki, otsikolla "The Art of Computer Programming", kirjoittajalla "Knuth, Donald", jonka ISBN on "0-201-03801-3", julkaisupaikalla "USA", kustantajalla "kustantaja" ja julkaisuvuodella "2008" lisataan
+        When  listataan kaikki lukuvinkit
+        Then  ohjelma vastaa tulosteella, jossa kirjan vari "sininen"
+
+Scenario: Listattu artikkelivinkki tulostuu halutulla värillä
+        Given uusi artikkelivinkki, urlilla "http://www.testiartikkeli.com/artikkeli1", otsikolla "Cucumberista", kirjoittajalla "Maestro, P", julkaisulla "" ja julkaisupaivalla "" annetaan
+        When  listataan kaikki lukuvinkit
+        Then  ohjelma vastaa tulosteella, jossa artikkelin vari "sinivihrea"
+

--- a/src/test/resources/vinkr/varit_vinkkityypeissa.feature
+++ b/src/test/resources/vinkr/varit_vinkkityypeissa.feature
@@ -10,3 +10,8 @@ Scenario: Listattu artikkelivinkki tulostuu halutulla värillä
         When  listataan kaikki lukuvinkit
         Then  ohjelma vastaa tulosteella, jossa artikkelin vari "sinivihrea"
 
+Scenario: Listattu youtubevinkki tulostuu halutulla värillä
+        Given uusi youtubevinkki, urlilla "https://www.youtube.com/watch?v=dQw4w9WgXcQ", otsikolla "RickRolling", kanavalla "Official Rick Astley" ja julkaisupaivalla "24.10.2009" annetaan
+        When  listataan kaikki lukuvinkit
+        Then  ohjelma vastaa tulosteella, jossa youtubevideon vari "violetti"
+


### PR DESCRIPTION
Niille storyille featuret, jotka selkeesti määritettävissä. Myös testit tehty näihin valmiiksi - osaa ei tosin ole otettu käyttöön.

Lisäksi muokattu TextUI:n avaa -komennon tilannetta, jossa annettu numero on epävalidi. Nyt ohjelma palaa pois avaamisvalikosta, sen sijaan että pyytäisi validia numeroa niin kauan kuin se annetaan. Motiivi tälle:
- tuntui olevan ainoa mielekäs tapa saada cucumber -testit toimimaan millekään linkin avaamiseen liittyvälle funktionaalisuudelle
- kenties parempi käyttäjälle, että voi palata esim. listaamaan ja etsimään oikean numeron, jos sitä ei ole mielessä?